### PR TITLE
Fix Incorrect Default Toolchain Tag in Core Library

### DIFF
--- a/core/wbab_core.py
+++ b/core/wbab_core.py
@@ -764,7 +764,7 @@ class Executor:
         # Security: Remote RCE Guard - Never run arbitrary host scripts.
         # Construct standard Docker run commands directly.
         
-        tag = os.environ.get("WBAB_TAG", "v0.2.4")
+        tag = os.environ.get("WBAB_TAG", "v0.2.0")
         project_dir = Path(args[0]) if args else Path(".")
         if not project_dir.is_absolute():
             project_dir = self.root_dir / project_dir


### PR DESCRIPTION
Updated `core/wbab_core.py` to use `v0.2.0` as the default `WBAB_TAG`. Verified locally via `tests/shell/run.sh` which now correctly targets `v0.2.0`.

---
*PR created automatically by Jules for task [13309038163426013878](https://jules.google.com/task/13309038163426013878) started by @mark-e-deyoung*