### PR TITLE
docs: Capture bidirectional analysis of WineBot/WBAB/WinInspect integration gaps

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -23,3 +23,22 @@
 
 ## Test Engineering
 - [x] **Item 10: Modernize Shell Unit Tests**: Transitioned `tests/shell/` and `tests/e2e/` to support containerized verification and Remote RCE Guard.
+
+## Cross-Project Integration (2026-07-05 Analysis)
+### WineBot → WBAB Improvements
+- [ ] **Item W1: WineBot v0.9.5→v0.9.7 Upgrade**: Bump default tag across 6+ files. Requires validating v0.9.7's new recording API contract, resource guardrails, and temporal correctness features work with WBAB's existing smoke pipeline.
+- [ ] **Item W2: Request Readiness Endpoint from WineBot**: Add `GET /ready` to WineBot API for deterministic smoke startup sequencing. WBAB would poll before exec-ing installer commands.
+- [ ] **Item W3: Request Install API from WineBot**: Structured `POST /apps/install` replacing multi-step compose-exec installer dance with single API call returning exit code + file manifest.
+- [ ] **Item W4: Request File Extraction API from WineBot**: `POST /files/read` replacing fragile `docker cp` + path-guessing logic in winebot-smoke.sh.
+- [ ] **Item W5: Request User-Mode Cert Trust API from WineBot**: Single `POST /certs/trust` replacing dual-user (root+winebot) exec in winebot-trust-dev-cert.sh.
+- [ ] **Item W6: Request CI Smoke Profile from WineBot**: `ci-smoke` compose profile that auto-captures evidence and produces structured `smoke-result.json`.
+- [ ] **Item W7: Request Versioned API Contract from WineBot**: `GET /version` returning capabilities list for compatibility detection.
+
+### WBAB → WinInspect Improvements
+- [ ] **Item B1: MSVC-Capable Build Image (Hard Blocker)**: Create MSVC winbuild variant (`tools/winbuild/Dockerfile.msvc` or new image) using msvc-wine or xwin to provide Windows SDK + MSVC CRT under Wine. Without this, WBAB cannot build WinInspect.
+- [ ] **Item B2: C++ Linting in Linter Image**: Add `clang-format` and `clang-tidy` to `tools/linter/Dockerfile` for WinInspect's C++ codebase. Add C++ file detection to `scripts/lint-container.sh`.
+- [ ] **Item B3: Go Toolchain in Winbuild Image**: Add `golang-go` package for WinInspect's Go components (2.8% of codebase).
+- [ ] **Item B4: Daemon-Aware Test Lifecycle**: Extend `test-real.sh` with pre/post command hooks for daemon-based test suites (required for WinInspect's daemon→client test pattern).
+- [ ] **Item B5: Recursive Submodule Support**: Add `WBAB_GIT_CLONE_RECURSIVE` flag or auto-detect `.gitmodules` in `GitSourceManager.prepare_source()`.
+- [ ] **Item B6: WinInspect Contract Tests**: Add `tests/contract/test_wininspect_pipeline.sh` validating plan JSON shape for C++/CMake project type.
+- [ ] **Item B7: Project Type Auto-Detection**: Extend `wbab doctor` to recognize WinInspect-style projects (CMakeLists.txt + clients/ + daemon/) and provide targeted diagnostics.

--- a/STATE.md
+++ b/STATE.md
@@ -1,4 +1,4 @@
-# WBAB Project State - 2026-02-18
+# WBAB Project State - 2026-07-05
 
 ## Overview
 The WineBotAppBuilder (WBAB) project has transitioned from a bring-up scaffold to a production-hardened, scalable, and secure containerized toolchain for Windows development.
@@ -30,8 +30,14 @@ The system is now fully stabilized, featuring a hardened CI/CD pipeline, SQLite 
 ## Active Constraints
 - **Policy Enforcement**: Strict adherence to `ORGANIZATION_POLICY.md` (4-tier structure) and `LINT_POLICY.md`.
 - **Security**: No host-side script execution for core verbs in production.
+- **WineBot version pin**: WBAB pins WineBot at `v0.9.5` in 6+ files; upstream is `v0.9.7`. Gap includes resource guardrails, temporal correctness, recording contracts, and lifecycle hardening.
+- **MSVC/MinGW blocker**: `tools/winbuild/Dockerfile` provides MinGW cross-compilation only (`x86_64-w64-mingw32-gcc/g++`). WinInspect requires MSVC (Visual Studio Build Tools + Windows SDK). This is the fundamental architecture mismatch preventing WBAB from building WinInspect.
 
 ## Next Steps
 - [ ] **Issue #7**: Implement Web-Based Operations Dashboard.
 - [ ] **Issue #8**: Enable TLS by default for daemon communication.
 - [ ] **Issue #3**: Implement Declarative Dependency Management ("Vending Machine").
+- [ ] **WineBot v0.9.7 upgrade**: Bump `WBAB_WINEBOT_TAG` default to `v0.9.7` across all integration points and validate recording API convergence model works with existing winebot-smoke.sh.
+- [ ] **MSVC build path for WinInspect**: Create MSVC-capable winbuild variant (`tools/winbuild/Dockerfile.msvc` or separate image) using `msvc-wine` or native Windows runner to enable building WinInspect within WBAB's pipeline.
+- [ ] **C++ linting support**: Extend linter image with `clang-format` and `clang-tidy` for WinInspect's C++ codebase.
+- [ ] **WinInspect contract tests**: Add pipeline shape validation for C++/CMake projects following WinInspect's daemon/client architecture.

--- a/docs/CONTEXT_BUNDLE.md
+++ b/docs/CONTEXT_BUNDLE.md
@@ -89,3 +89,6 @@ TLA CI execution notes:
 - Add concrete Dockerfiles for release GHCR publish workflow outputs
 - Add core daemon/library with idempotent command processing
 - Add formal model (TLA+) and model-validated tests
+- **WineBot v0.9.7 upgrade**: Bump default tag, validate recording API + resource guardrails
+- **MSVC build path**: Create MSVC-capable winbuild variant for WinInspect support
+- **Cross-project integration**: C++ linting, Go toolchain, daemon-aware test lifecycle, WinInspect contract tests (see BACKLOG.md for full inventory)

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -105,7 +105,8 @@ The CLI must expose these verbs (even if some are stubbed initially):
 ## Policy constraints (must hold)
 - If `WBAB_ALLOW_LOCAL_BUILD != 1`, the system must not invoke `docker build` for build/package/sign images.
 - WineBot runs are pull-first from GHCR; local WineBot build path is disabled.
-- CI policy: prefer official `ghcr.io/mark-e-deyoung/winebot:v0.9.5` for WineBot runs.
+- CI policy: prefer official `ghcr.io/mark-e-deyoung/winebot:v0.9.5` for WineBot runs. **Note:** Upstream WineBot is at `v0.9.7`; upgrade requires coordinated tag bump across all integration points (BACKLOG.md Items W1-W7).
+- WinInspect builds require MSVC toolchain; current winbuild container uses MinGW cross-compilation only. Creating MSVC build path is a prerequisite (BACKLOG.md Item B1).
 - Commit policy: one git commit per requested implementation change unless the user explicitly requests batching.
 - Build/package default fixture commands must use concrete container scripts (`tools/winbuild/build-fixture.sh`, `tools/packaging/package-fixture.sh`) with output validation.
 - Core baseline policy: repeated `wbabd run <same-op-id> ...` must not re-execute succeeded operations.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,6 +1,6 @@
 # Project State
 
-**Date:** 2026-02-09
+**Date:** 2026-07-05
 
 ## Status
 Bring-up scaffold created and partially implemented. `doctor`, `build`, `package`, `sign`, `smoke`, and `plan` are now
@@ -189,3 +189,9 @@ Dependency versions (`hadolint`, `trivy`) updated to latest stable.
 
 ## Next actions
 1. Publish toolchain images to GHCR
+
+## Cross-project analysis (2026-07-05)
+See `STATE.md` (root) and `BACKLOG.md` for the latest bidirectional analysis of WineBot→WBAB and WBAB→WinInspect improvements. Key findings:
+- **WineBot v0.9.5→v0.9.7 gap**: 6+ files pin the older tag; v0.9.7 has resource guardrails, temporal correctness, recording contracts
+- **MSVC/MinGW blocker**: `tools/winbuild/Dockerfile` cannot build WinInspect (requires MSVC toolchain)
+- **14 actionable items** catalogued in BACKLOG.md across both improvement directions


### PR DESCRIPTION
## Summary

This PR documents the findings from a thorough analysis of reciprocal improvements between the three projects in the SemperSupra ecosystem:

### WineBot → WBAB Improvements (7 items)
- W1: v0.9.5→v0.9.7 upgrade (currently pinned across 6+ files)
- W2-W7: New WineBot API features (readiness, install, file extraction, cert trust, CI smoke profile, versioned API contract)

### WBAB → WinInspect Improvements (7 items)
- B1: **MSVC build path** — hard blocker; winbuild only has MinGW
- B2-B7: C++ linting, Go toolchain, daemon-aware test lifecycle, recursive submodule support, contract tests, project type detection

### Files Changed
- `BACKLOG.md` — Added full catalog of 14 improvement items
- `STATE.md` — Updated with blocker, gap, new Next Steps
- `docs/CONTRACTS.md` — Annotated policy constraints
- `docs/CONTEXT_BUNDLE.md` — Extended next increments
- `docs/STATE.md` — Date refresh + cross-reference

## Status
Analysis only — no code changes. Working tree remains clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)