### PR TITLE
B3: Add Go toolchain (golang-go) to winbuild Dockerfile

### DIFF
--- a/tools/winbuild/Dockerfile
+++ b/tools/winbuild/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     g++ \
     gcc-mingw-w64 \
     git \
+    golang-go \
     make \
     mingw-w64 \
     ninja-build \


### PR DESCRIPTION
## Summary

Adds `golang-go` package to the winbuild Dockerfile so WinInspect's Go components can be cross-compiled in the WBAB build pipeline. WinInspect includes a `go.mod` and Go CLI builds as part of its codebase.

## Changes

- `tools/winbuild/Dockerfile`: Added `golang-go` in alphabetical order in the apt-get install list

## Testing

- Dockerfile uses the same `debian:trixie-slim` base and the same `apt-get install --no-install-recommends` pattern as all existing packages
- Policy tests (base image, file existence) pass
- Dry-check will validate via CI (`docker buildx build --check`)

Closes #31