### PR TITLE
B5: Add WBAB_GIT_CLONE_RECURSIVE env var for submodule control

### DIFF
--- a/core/scm.py
+++ b/core/scm.py
@@ -78,15 +78,17 @@ class GitSourceManager:
                     timeout=timeout,
                 )
 
-            # Update submodules recursively
-            subprocess.run(
-                ["git", "submodule", "update", "--init", "--recursive", "--quiet"],
-                cwd=temp_dir,
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
+            # Update submodules unless explicitly disabled
+            recursive = os.environ.get("WBAB_GIT_CLONE_RECURSIVE", "1")
+            if recursive != "0":
+                subprocess.run(
+                    ["git", "submodule", "update", "--init", "--recursive", "--quiet"],
+                    cwd=temp_dir,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
 
             yield temp_dir
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -18,6 +18,7 @@ The CLI must expose these verbs (even if some are stubbed initially):
 ## Required environment variables
 - `WBAB_TAG` (recommended): toolchain image tag to pull (e.g., `v1.0.0`)
 - `WBAB_ALLOW_LOCAL_BUILD` (default `0`): allow building toolchain images locally
+- `WBAB_GIT_CLONE_RECURSIVE` (default `1`): control recursive submodule init in `GitSourceManager`; set to `0` to skip `git submodule update --init --recursive` after clone
 - `WBAB_WINEBOT_IMAGE` (default `ghcr.io/mark-e-deyoung/winebot`): WineBot image
 - `WBAB_WINEBOT_TAG` (default `v0.9.5`): WineBot image tag
 - `WBAB_WINEBOT_PROFILE` (default `headless`): compose profile

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -1,12 +1,16 @@
+import os
+import shutil
+import tempfile
 import unittest
-import sys
+from unittest.mock import MagicMock, patch
 from pathlib import Path
+import sys
 
 # Add repo root to path
 ROOT_DIR = Path(__file__).parents[2]
 sys.path.insert(0, str(ROOT_DIR))
 
-from core.scm import sanitize_git_url  # noqa: E402
+from core.scm import GitSourceManager, sanitize_git_url  # noqa: E402
 
 
 class TestSCM(unittest.TestCase):
@@ -37,6 +41,77 @@ class TestSCM(unittest.TestCase):
             sanitize_git_url("git@github.com:user/repo.git"),
             "git@github.com:user/repo.git",
         )
+
+
+class TestGitSourceManagerRecursive(unittest.TestCase):
+    def setUp(self):
+        self.root_dir = Path(tempfile.mkdtemp())
+        self.manager = GitSourceManager(self.root_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.root_dir, ignore_errors=True)
+
+    @patch("core.scm.subprocess.run")
+    @patch("core.scm.os.environ", {
+        "WBAB_GIT_TIMEOUT_SECS": "300",
+        "WBAB_GIT_ALLOWED_DOMAINS": "",
+    })
+    def test_prepare_source_recursive_default(self, mock_run):
+        """When WBAB_GIT_CLONE_RECURSIVE is unset, submodule update should run."""
+        mock_run.return_value = MagicMock()
+        try:
+            with self.manager.prepare_source("https://github.com/test/a.git", "main") as path:
+                self.assertTrue(path.exists())
+        except Exception:
+            pass
+        # clone + checkout + submodule update = 3 calls
+        self.assertGreaterEqual(mock_run.call_count, 2)
+        # Check the last call was submodule update
+        all_cmds = []
+        for call_args in mock_run.call_args_list:
+            all_cmds.extend(call_args[0][0])
+        cmd_str = " ".join(all_cmds)
+        self.assertIn("submodule", cmd_str, "Expected submodule update when env var unset")
+
+    @patch("core.scm.subprocess.run")
+    @patch("core.scm.os.environ", {
+        "WBAB_GIT_TIMEOUT_SECS": "300",
+        "WBAB_GIT_ALLOWED_DOMAINS": "",
+        "WBAB_GIT_CLONE_RECURSIVE": "1",
+    })
+    def test_prepare_source_recursive_enabled(self, mock_run):
+        """When WBAB_GIT_CLONE_RECURSIVE=1, submodule update should run."""
+        mock_run.return_value = MagicMock()
+        try:
+            with self.manager.prepare_source("https://github.com/test/a.git", "main") as path:
+                self.assertTrue(path.exists())
+        except Exception:
+            pass
+        all_cmds = []
+        for call_args in mock_run.call_args_list:
+            all_cmds.extend(call_args[0][0])
+        cmd_str = " ".join(all_cmds)
+        self.assertIn("submodule", cmd_str, "Expected submodule update when RECURSIVE=1")
+
+    @patch("core.scm.subprocess.run")
+    @patch("core.scm.os.environ", {
+        "WBAB_GIT_TIMEOUT_SECS": "300",
+        "WBAB_GIT_ALLOWED_DOMAINS": "",
+        "WBAB_GIT_CLONE_RECURSIVE": "0",
+    })
+    def test_prepare_source_recursive_disabled(self, mock_run):
+        """When WBAB_GIT_CLONE_RECURSIVE=0, submodule update should NOT run."""
+        mock_run.return_value = MagicMock()
+        try:
+            with self.manager.prepare_source("https://github.com/test/a.git", "main") as path:
+                self.assertTrue(path.exists())
+        except Exception:
+            pass
+        all_cmds = []
+        for call_args in mock_run.call_args_list:
+            all_cmds.extend(call_args[0][0])
+        cmd_str = " ".join(all_cmds)
+        self.assertNotIn("submodule", cmd_str, "Expected no submodule update when RECURSIVE=0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds `WBAB_GIT_CLONE_RECURSIVE` environment variable to `GitSourceManager.prepare_source()` so callers can control whether `git submodule update --init --recursive` runs after checkout. Default is `1` (current behavior, recursive submodules). Set to `0` to skip.

## Changes

- `core/scm.py`: Check `WBAB_GIT_CLONE_RECURSIVE` env var; skip submodule update when set to `0`
- `tests/unit/test_scm.py`: Added `TestGitSourceManagerRecursive` with 3 test cases (default, enabled, disabled)
- `docs/CONTRACTS.md`: Documented new env var

## Testing

- `python3 -m unittest tests/unit/test_scm.py -v` — all 4 tests pass

Closes #32