### PR TITLE
B7: Add WinInspect project type detection to wbab doctor

### DIFF
--- a/tests/contract/test_cli_ux.sh
+++ b/tests/contract/test_cli_ux.sh
@@ -55,4 +55,22 @@ echo "${SHEBANG}" | grep -qE "^#!/" || {
   exit 1
 }
 
+# 9. Doctor detects WinInspect-style project
+echo "  [9] doctor detects WinInspect project type"
+WI_TMP="$(mktemp -d)"
+trap 'rm -rf "${WI_TMP}"' EXIT
+touch "${WI_TMP}/CMakeLists.txt"
+mkdir -p "${WI_TMP}/clients" "${WI_TMP}/daemon"
+WI_DOCTOR=$("${WBAB}" doctor "${WI_TMP}" 2>&1 || true)
+echo "${WI_DOCTOR}" | grep -qi "WinInspect" || {
+  echo "FAIL: doctor did not detect WinInspect project type" >&2
+  exit 1
+}
+echo "${WI_DOCTOR}" | grep -qi "CMake" || {
+  echo "FAIL: doctor did not mention CMake for WinInspect project" >&2
+  exit 1
+}
+rm -rf "${WI_TMP}"
+trap 'rm -rf "${TMP}"' EXIT
+
 echo "OK: CLI UX contracts satisfied"

--- a/tools/wbab
+++ b/tools/wbab
@@ -13,7 +13,7 @@ EXIT_NOT_IMPLEMENTED=10
 
 usage() {
   cat <<'EOF'
-WineBotAppBuilder (wbab)
+WineBotAppBuilder (wbab) v0.3.7
 
 Usage:
   wbab <verb> [args...]
@@ -73,6 +73,11 @@ except ImportError:
 
 cmd_doctor() {
   local ok=1
+  local target="${1:-}"
+  if [[ -n "${target}" && "${target}" != /* ]]; then
+    target="${ROOT_DIR}/${target}"
+  fi
+  local target="${target:-${ROOT_DIR}}"
 
   if command -v docker >/dev/null 2>&1; then
     if docker compose version >/dev/null 2>&1; then
@@ -101,6 +106,23 @@ cmd_doctor() {
     echo "doctor: WineBot compose file missing at tools/WineBot/compose/docker-compose.yml" >&2
     echo "doctor: hint: run ./scripts/bootstrap-submodule.sh" >&2
     ok=0
+  fi
+
+  # Project type detection (diagnostic, does not affect exit code)
+  if [[ -f "${target}/CMakeLists.txt" ]]; then
+    if [[ -d "${target}/clients" && -d "${target}/daemon" ]]; then
+      echo "doctor: project type: WinInspect (CMake + clients/ + daemon/)"
+      echo "doctor:   hint: set WBAB_GIT_CLONE_RECURSIVE=1 for submodule support"
+      if command -v x86_64-w64-mingw32-g++ &>/dev/null; then
+        echo "doctor:   MinGW cross-compiler (x86_64-w64-mingw32-g++) available"
+      else
+        echo "doctor:   MinGW cross-compiler not available locally; use winbuild container"
+      fi
+    elif [[ -d "${target}/core" ]]; then
+      echo "doctor: project type: C++/CMake project with core library"
+    else
+      echo "doctor: project type: CMake-based project"
+    fi
   fi
 
   if [[ "${ok}" -eq 1 ]]; then
@@ -300,7 +322,9 @@ EOF
   "steps": [
     "check_docker",
     "check_compose",
-    "check_winebot_submodule"
+    "check_winebot_submodule",
+    "detect_project_type",
+    "check_mingw_cross_compiler"
   ]
 }
 EOF


### PR DESCRIPTION
## Summary

Extends `wbab doctor` with WinInspect project type detection and fixes a pre-existing version reference warning in the help text.

## Changes

- `tools/wbab`: 
  - `cmd_doctor()` now accepts optional target directory argument
  - Detects WinInspect-style projects (CMakeLists.txt + clients/ + daemon/)
  - Prints MinGW cross-compiler availability for Win32 targets
  - Provides targeted hints for submodule and build config
  - Added version string (v0.3.7) to usage banner (fixes pre-existing contract test warning)
  - Updated `plan doctor` JSON steps to include project detection
- `tests/contract/test_cli_ux.sh`: Added test [9] for WinInspect project type detection

## Testing

- `tests/contract/run.sh` — all contract tests pass
- `tests/shell/run.sh` — all shell tests pass
- Manual: `wbab doctor /tmp/wi-project` with CMakeLists.txt + clients/ + daemon/ correctly detects WinInspect type

Closes #33