### PR TITLE
feat: expose configurable retry backoff via env vars

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,7 +9,7 @@
 - [x] **Item 1: SQLite for Persistence**: Implemented SQLite-backed `OperationStore` and `AuditLog` for better scalability.
 - [x] **Item 2: Worker Pool Control**: Implemented `asyncio.Semaphore` in `wbabd` to limit concurrent tasks.
 - [x] **Item 3: Discovery Caching**: Implemented local caching of discovered daemon URLs in `wbab` CLI.
-- [ ] **Item 4: Configurable Backoff**: Expose `WBAB_RETRY_BACKOFF_BASE` for fine-tuning throttling. (Deferred)
+- [x] **Item 4: Configurable Backoff**: Expose `WBAB_RETRY_BACKOFF_BASE` and `WBAB_RETRY_BACKOFF_MAX` for fine-tuning retry throttling.
 - [ ] **Item 5: CI/CD Trivy Caching**: Implement `actions/cache` in GitHub workflows to persist the vulnerability database across runs. (Low Priority)
 - [ ] **Item 6: mDNS Metadata Enhancement**: Add `version`, `auth_mode`, and `tls_enabled` to mDNS TXT records for better CLI pre-flight checks. (Deferred)
 - [ ] **Item 7: Git Mirrors**: Implement persistent Git mirrors in `agent-sandbox` to speed up source preparation. (Deferred)

--- a/core/wbab_core.py
+++ b/core/wbab_core.py
@@ -476,7 +476,19 @@ class Executor:
     def _get_backoff_delay(self, attempts: int) -> int:
         if attempts <= 1:
             return 0
-        return min(300, 2**attempts)
+        try:
+            base = int(os.environ.get("WBAB_RETRY_BACKOFF_BASE", "2"))
+        except (ValueError, TypeError):
+            base = 2
+        try:
+            max_delay = int(os.environ.get("WBAB_RETRY_BACKOFF_MAX", "300"))
+        except (ValueError, TypeError):
+            max_delay = 300
+        if base < 2:
+            base = 2
+        if max_delay < 1:
+            max_delay = 300
+        return min(max_delay, base**attempts)
 
     def _validate_outputs(self, plan: Plan) -> bool:
         project_dir = Path(plan.args[0]) if plan.args else Path(".")

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -31,6 +31,8 @@ The CLI must expose these verbs (even if some are stubbed initially):
 - `WBAB_LINT_CMD` (default `wbab-lint`): lint command executed in toolchain container
 - `WBAB_TEST_CMD` (default `wbab-test`): test command executed in toolchain container
 - `WBAB_EXECUTION_TIMEOUT_SECS` (default `3600`): max seconds for a single execution step
+- `WBAB_RETRY_BACKOFF_BASE` (default `2`): exponential base for retry backoff (`base^attempts`); clamped to minimum of 2
+- `WBAB_RETRY_BACKOFF_MAX` (default `300`): maximum retry backoff delay in seconds; clamped to minimum of 1
 - `WBAB_PACKAGER_IMAGE` (default `ghcr.io/sempersupra/winebotappbuilder-packager`): packager image
 - `WBAB_PACKAGER_DOCKERFILE` (default `tools/packaging/Dockerfile`): local packager Dockerfile path
 - `WBAB_PACKAGE_CMD` (default consumes `out/FakeApp.exe`, creates `dist/FakeSetup.exe` + `dist/package-fixture.txt`): package command executed in packager container

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -1,16 +1,20 @@
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 from pathlib import Path
-import sys
 
 # Add repo root to path
 ROOT_DIR = Path(__file__).parents[2]
 sys.path.insert(0, str(ROOT_DIR))
 
+# Mock fcntl before importing wbab_core (not available on Windows)
+sys.modules["fcntl"] = MagicMock()
+
 from core.scm import GitSourceManager, sanitize_git_url  # noqa: E402
+from core.wbab_core import Executor, OperationStore  # noqa: E402
 
 
 class TestSCM(unittest.TestCase):
@@ -116,3 +120,76 @@ class TestGitSourceManagerRecursive(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestBackoffDelay(unittest.TestCase):
+    """Tests for Executor._get_backoff_delay() configurable backoff."""
+
+    def setUp(self):
+        self.root_dir = Path(tempfile.mkdtemp())
+        self.store = MagicMock(spec=OperationStore)
+        self.audit = MagicMock()
+        self.executor = Executor(self.root_dir, self.store, audit=self.audit)
+
+    def tearDown(self):
+        shutil.rmtree(self.root_dir, ignore_errors=True)
+
+    def test_backoff_defaults(self):
+        """Default base=2, max=300."""
+        self.assertEqual(self.executor._get_backoff_delay(0), 0)
+        self.assertEqual(self.executor._get_backoff_delay(1), 0)
+        self.assertEqual(self.executor._get_backoff_delay(2), 4)
+        self.assertEqual(self.executor._get_backoff_delay(3), 8)
+        self.assertEqual(self.executor._get_backoff_delay(4), 16)
+        self.assertEqual(self.executor._get_backoff_delay(9), 300)  # capped
+
+    def test_backoff_attempts_zero_and_one_always_zero(self):
+        """0 and 1 attempts always return 0 regardless of env settings."""
+        with patch.dict(os.environ, {"WBAB_RETRY_BACKOFF_BASE": "10"}):
+            self.assertEqual(self.executor._get_backoff_delay(0), 0)
+            self.assertEqual(self.executor._get_backoff_delay(1), 0)
+        with patch.dict(os.environ, {"WBAB_RETRY_BACKOFF_MAX": "0"}):
+            self.assertEqual(self.executor._get_backoff_delay(0), 0)
+            self.assertEqual(self.executor._get_backoff_delay(1), 0)
+
+    @patch.dict(os.environ, {"WBAB_RETRY_BACKOFF_BASE": "3"})
+    def test_backoff_custom_base(self):
+        """When WBAB_RETRY_BACKOFF_BASE=3, delay uses 3^attempts."""
+        self.assertEqual(self.executor._get_backoff_delay(2), 9)
+        self.assertEqual(self.executor._get_backoff_delay(3), 27)
+        self.assertEqual(self.executor._get_backoff_delay(4), 81)
+
+    @patch.dict(os.environ, {"WBAB_RETRY_BACKOFF_MAX": "10"})
+    def test_backoff_custom_max(self):
+        """When WBAB_RETRY_BACKOFF_MAX=10, delay is capped at 10."""
+        self.assertEqual(self.executor._get_backoff_delay(4), 10)
+        self.assertEqual(self.executor._get_backoff_delay(9), 10)
+
+    @patch.dict(os.environ, {
+        "WBAB_RETRY_BACKOFF_BASE": "3",
+        "WBAB_RETRY_BACKOFF_MAX": "50",
+    })
+    def test_backoff_custom_base_and_max(self):
+        """Both env vars together produce correct values."""
+        self.assertEqual(self.executor._get_backoff_delay(2), 9)
+        self.assertEqual(self.executor._get_backoff_delay(3), 27)
+        self.assertEqual(self.executor._get_backoff_delay(4), 50)
+
+    def test_backoff_non_numeric_base_falls_back(self):
+        """Non-numeric WBAB_RETRY_BACKOFF_BASE falls back to default 2."""
+        with patch.dict(os.environ, {"WBAB_RETRY_BACKOFF_BASE": "not-a-number"}):
+            self.assertEqual(self.executor._get_backoff_delay(2), 4)
+            self.assertEqual(self.executor._get_backoff_delay(3), 8)
+
+    def test_backoff_non_numeric_max_falls_back(self):
+        """Non-numeric WBAB_RETRY_BACKOFF_MAX falls back to default 300."""
+        with patch.dict(os.environ, {"WBAB_RETRY_BACKOFF_MAX": "not-a-number"}):
+            self.assertEqual(self.executor._get_backoff_delay(2), 4)
+            self.assertEqual(self.executor._get_backoff_delay(9), 300)
+
+    def test_backoff_base_too_low_clamped(self):
+        """Base < 2 is clamped to 2."""
+        with patch.dict(os.environ, {"WBAB_RETRY_BACKOFF_BASE": "0"}):
+            self.assertEqual(self.executor._get_backoff_delay(2), 4)
+        with patch.dict(os.environ, {"WBAB_RETRY_BACKOFF_BASE": "1"}):
+            self.assertEqual(self.executor._get_backoff_delay(2), 4)


### PR DESCRIPTION
## Summary

Exposes `WBAB_RETRY_BACKOFF_BASE` and `WBAB_RETRY_BACKOFF_MAX` environment variables to allow users to tune retry throttling behavior without modifying source code.

## Changes

- **`core/wbab_core.py`**: Updated `_get_backoff_delay()` to read `WBAB_RETRY_BACKOFF_BASE` (default `2`) and `WBAB_RETRY_BACKOFF_MAX` (default `300`) from environment. Both fall back to defaults if unset, non-numeric, or out of range (base < 2 clamped to 2, max < 1 clamped to 300).
- **`tests/unit/test_scm.py`**: Added `TestBackoffDelay` class with 8 tests covering defaults, custom values, combined settings, non-numeric fallback, and clamping.
- **`docs/CONTRACTS.md`**: Documented new env vars.
- **`BACKLOG.md`**: Marked Item 4 as completed.

## Testing

```
$ python3 -m unittest discover -s tests/unit -p "*.py"
.. (12 tests, all pass)
```

Closes #41