### PR TITLE
feat: add local CI workflow testing with nektos/act

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,2 @@
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+--artifact-server-path .act/artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: help act-ci act-lint test unit-test
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+# ── Local CI (nektos/act) ──────────────────────────────────────────────────
+
+act-ci: ## Run full CI workflow locally with act
+	act -j lint -j shell-unit -j contract -j policy -j python-unit -j e2e-smoke
+
+act-lint: ## Run only the lint job locally
+	act -j lint
+
+act-test: ## Run all test jobs locally
+	act -j shell-unit -j contract -j policy -j python-unit -j e2e-smoke
+
+# ── Python Tests ──────────────────────────────────────────────────────────
+
+unit-test: ## Run Python unit tests
+	python3 -m unittest discover -s tests/unit -p "*.py" -v
+
+# ── Lint ───────────────────────────────────────────────────────────────────
+
+lint: ## Run containerized lint
+	./scripts/lint.sh


### PR DESCRIPTION
## Summary

Adds configuration for running GitHub Actions CI workflows locally using `nektos/act`, enabling developers to validate CI changes before pushing.

## Changes

- **`.actrc`**: Default act configuration with `ubuntu-latest` mapped to the `catthehacker/ubuntu:act-latest` image and artifact server configured.
- **`Makefile`**: Added `act-ci`, `act-lint`, and `act-test` targets, plus `unit-test` and `lint` convenience targets.

## Usage

```bash
# Install act (one-time)
# macOS: brew install act
# Linux: curl -sSL https://github.com/nektos/act/releases/... | ...

# Run full CI locally
make act-ci

# Run just the lint job
make act-lint

# Run Python unit tests directly
make unit-test
```

## Dependencies

- `nektos/act` (community-standard tool, 55k+ GitHub stars)
- Docker (already required by the project)

Closes #45