### PR TITLE
fix: add .dockerignore to reduce build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Version control
+.git/
+.gitignore
+.gitattributes
+
+# Build artifacts
+out/
+dist/
+artifacts/
+samples/*/build/
+samples/*/out/
+samples/*/dist/
+
+# Runtime state
+agent-sandbox/
+agent-privileged/
+.wbab/
+.wbab.lock
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+coverage_html/
+
+# Node (if present)
+node_modules/
+
+# Secrets
+.env
+*.key
+*.pem
+*.pfx
+
+# Editor / temp files
+*.swp
+*.tmp
+*.swo
+
+# Local CI (act)
+.act/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Documentation and session files
+HANDoFF.md


### PR DESCRIPTION
## Summary

Adds a `.dockerignore` file to exclude unnecessary files from Docker build context, reducing context size and speeding up image builds.

## Changes

- **`.dockerignore`**: Excludes `.git/`, build artifacts (`out/`, `dist/`, `artifacts/`), Python cache (`__pycache__/`), runtime state (`agent-sandbox/`, `.wbab/`), secrets (`.env`, `*.key`, `*.pem`), temp files, and other unnecessary files from Docker build context.

All four Dockerfiles (linter, winbuild, packager, signer) use the repo root as build context. Without a `.dockerignore`, Docker sends the entire working tree (including potentially large directories) to the daemon on every build.